### PR TITLE
[FEAT] global exception 추가

### DIFF
--- a/src/main/kotlin/com/pravo/pravo/domain/member/service/MemberService.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/member/service/MemberService.java
@@ -1,10 +1,9 @@
 package com.pravo.pravo.domain.member.service;
 
-import com.pravo.pravo.domain.member.model.Member;
 import com.pravo.pravo.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
+import com.pravo.pravo.global.common.error.exception.UnauthorizedException;
+import com.pravo.pravo.global.common.error.ErrorCode;
 
 @Service
 public class MemberService {
@@ -12,5 +11,11 @@ public class MemberService {
 
     public MemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
+    }
+
+    public void validateMemberById(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -4,6 +4,7 @@ import com.pravo.pravo.domain.promise.dto.request.PromiseSearchDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
 import com.pravo.pravo.domain.promise.service.PromiseService
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -16,9 +17,9 @@ class PromiseController(
     @GetMapping
     override fun getPromisesByMember(
         @RequestParam memberId: Long,
-        @RequestParam request: PromiseSearchDto?,
+        @ModelAttribute request: PromiseSearchDto?,
     ): List<PromiseResponseDto> {
-        // TODO: 토큰 기반 유저 인증 추가 및 유저 401 에러 처리
+        // TODO: 토큰 기반 유저 인증 추가
         return promiseService.getPromisesByMember(memberId, request?.startedAt, request?.endedAt)
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
@@ -1,17 +1,22 @@
 package com.pravo.pravo.domain.promise.service
 
+import com.pravo.pravo.domain.member.service.MemberService
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
 import com.pravo.pravo.domain.promise.repository.PromiseRepository
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
 @Service
-class PromiseService(private val promiseRepository: PromiseRepository) {
+class PromiseService(
+    private val promiseRepository: PromiseRepository,
+    private val memberService: MemberService,
+) {
     fun getPromisesByMember(
         memberId: Long,
         startedAt: LocalDate?,
         endedAt: LocalDate?,
     ): List<PromiseResponseDto> {
+        memberService.validateMemberById(memberId)
         return promiseRepository.getPromisesByMemberIdAndStartedAtAndEndedAt(memberId, startedAt, endedAt)
             .map(PromiseResponseDto::of)
     }

--- a/src/main/kotlin/com/pravo/pravo/global/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/pravo/pravo/global/common/error/ErrorCode.kt
@@ -1,0 +1,14 @@
+package com.pravo.pravo.global.common.error
+
+enum class ErrorCode(
+    val message: String,
+    val status: Int,
+    val code: String,
+) {
+    INTERNAL_SERVER_ERROR("Internal Server Error", 500, "E01"),
+    BAD_REQUEST("Bad Request", 400, "E02"),
+    UNAUTHORIZED("Unauthorized Member", 401, "E03"),
+    FORBIDDEN("Forbidden", 403, "E04"),
+    NOT_FOUND("Not Found", 404, "E05"),
+    METHOD_NOT_ALLOWED("Method Not Allowed", 405, "E06"),
+}

--- a/src/main/kotlin/com/pravo/pravo/global/common/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/pravo/pravo/global/common/error/ErrorResponse.kt
@@ -1,0 +1,20 @@
+package com.pravo.pravo.global.common.error
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ErrorResponse(
+    @Schema(description = "HTTP 응답 메시지", example = "API Request is failed.")
+    val message: String,
+    @Schema(description = "HTTP 상태 코드", example = "500")
+    val status: Int,
+    @Schema(description = "에러 코드", example = "E01")
+    val code: String,
+) {
+    constructor(
+        errorCode: ErrorCode,
+    ) : this(
+        message = errorCode.message,
+        status = errorCode.status,
+        code = errorCode.code,
+    )
+}

--- a/src/main/kotlin/com/pravo/pravo/global/common/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/pravo/pravo/global/common/error/GlobalExceptionHandler.kt
@@ -1,0 +1,38 @@
+package com.pravo.pravo.global.common.error
+
+import com.pravo.pravo.global.common.error.exception.UnauthorizedException
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(Exception::class)
+    protected fun handleException(exception: Exception): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+        val response = ErrorResponse(errorCode)
+        return ResponseEntity.ok(response)
+    }
+
+    @ExceptionHandler(EntityNotFoundException::class)
+    fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.NOT_FOUND
+        val response = ErrorResponse(errorCode)
+        return ResponseEntity.ok(response)
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    fun handleAuthenticationException(exception: AccessDeniedException): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.UNAUTHORIZED
+        val response = ErrorResponse(errorCode)
+        return ResponseEntity.ok(response)
+    }
+
+    @ExceptionHandler(UnauthorizedException::class)
+    fun handleUnauthorizedException(e: UnauthorizedException): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.UNAUTHORIZED
+        val response = ErrorResponse(errorCode)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/pravo/pravo/global/common/error/exception/BaseException.java
+++ b/src/main/kotlin/com/pravo/pravo/global/common/error/exception/BaseException.java
@@ -1,0 +1,12 @@
+package com.pravo.pravo.global.common.error.exception;
+
+import com.pravo.pravo.global.common.error.ErrorCode;
+
+public class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/kotlin/com/pravo/pravo/global/common/error/exception/UnauthorizedException.java
+++ b/src/main/kotlin/com/pravo/pravo/global/common/error/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.pravo.pravo.global.common.error.exception;
+
+import com.pravo.pravo.global.common.error.ErrorCode;
+
+public class UnauthorizedException extends BaseException {
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION

## 📌 관련 이슈
#9 Global Exception 설정

## ✨ 어떤 이유로 변경된 내용인지
- Global Exception을 추가했습니다.
- Java로 작성된 파일에서도 사용할 수 있게끔 BaseException을 Java로 작성했습니다.
- ErrorCode와 ErrorStatus, GlobalExeptionHandler는 Kotlin으로 작성했습니다.
- 가장 많이 사용 될 것 같은 Exception 4가지(기본, Entity not found, access denied, unauthorized)를 추가하였습니다.

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- PromiseController에서 @ModelAttirbute를 @RequestParam으로 변경하는 바람에 다중 param이 null로 인식되는 오류가 있었습니다. @ModelAtribute로 수정완료했습니다.
