### PR TITLE
Feat/#52 join promise api

### DIFF
--- a/src/main/kotlin/com/pravo/pravo/domain/member/model/Member.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/member/model/Member.java
@@ -5,10 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Column;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "member")
+@SQLRestriction("deleted = false")
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -18,6 +21,9 @@ public class Member extends BaseTimeEntity {
     private String name;
     private String profileImageUrl;
     private String socialId;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 
     //    private String refreshToken;
 

--- a/src/main/kotlin/com/pravo/pravo/domain/member/service/MemberService.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/member/service/MemberService.java
@@ -63,17 +63,16 @@ public class MemberService {
         return "Successfully logged out";
     }
 
-    public void validateMemberById(Long memberId) {
-        if (!memberRepository.existsById(memberId)) {
-            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
-        }
-    }
-
     public MyPageResponseDTO fetchMemberById(long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
                 () -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
         return MyPageResponseDTO.of(member);
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
     }
 
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentFacade.kt
@@ -1,11 +1,14 @@
 package com.pravo.pravo.domain.payment.service
 
+import com.pravo.pravo.domain.member.service.MemberService
 import com.pravo.pravo.domain.payment.dto.response.RequestOrderResponseDto
 import com.pravo.pravo.domain.payment.enums.PaymentStatus
 import com.pravo.pravo.domain.payment.model.Card
 import com.pravo.pravo.domain.payment.model.EasyPay
 import com.pravo.pravo.domain.payment.model.PaymentLog
 import com.pravo.pravo.domain.promise.dto.request.PromiseCreateDto
+import com.pravo.pravo.domain.promise.model.enums.RoleStatus
+import com.pravo.pravo.domain.promise.service.PromiseRoleService
 import com.pravo.pravo.domain.promise.service.PromiseService
 import com.pravo.pravo.global.external.toss.PaymentClient
 import com.pravo.pravo.global.external.toss.dto.request.ConfirmRequestDto
@@ -20,6 +23,8 @@ class PaymentFacade(
     private val paymentClient: PaymentClient,
     private val paymentService: PaymentService,
     private val promiseService: PromiseService,
+    private val promiseRoleService: PromiseRoleService,
+    private val memberService: MemberService,
 ) {
     val logger = logger()
 
@@ -35,6 +40,8 @@ class PaymentFacade(
 
         val pendingPaymentLog = PaymentLog.getPendingPaymentLog(id)
         val pendingPromise = promiseService.createPendingPromise(promiseCreateDto)
+        val member = memberService.getMemberById(memberId)
+        promiseRoleService.createPendingPromiseRole(member, pendingPromise, RoleStatus.ORGANIZER)
 
         return RequestOrderResponseDto.of(paymentService.savePaymentLog(pendingPaymentLog).orderId, pendingPromise.id)
     }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -72,4 +72,24 @@ interface PromiseApi {
     @Operation(summary = "Pending 약속 상태 변경", description = "결제 완료된 약속을 Ready 상태로 변경합니다.")
     @SecurityRequirement(name = "jwt")
     fun changePendingStatus(promiseId: Long): ApiResponseDto<Unit>
+
+    @Operation(summary = "약속 참가", description = "약속에 참가합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "약속 참가 성공",
+        content = [
+            Content(
+                schema = Schema(implementation = ApiResponseDto::class),
+            ),
+        ],
+    )
+    @SecurityRequirement(name = "jwt")
+    fun joinPromise(
+        @PathVariable promiseId: Long,
+        @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<PromiseResponseDto>
+
+    @Operation(summary = "Pending Promise Role 상태 변경", description = "약속 참가 - 결제 이후 모임원의 상태를 Ready 상태로 변경합니다.")
+    @SecurityRequirement(name = "jwt")
+    fun changeParticipantPendingStatus(promiseId: Long): ApiResponseDto<Unit>
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -66,7 +66,10 @@ interface PromiseApi {
 
     @Operation(summary = "Pending 약속 상태 변경", description = "결제 완료된 약속을 Ready 상태로 변경합니다.")
     @SecurityRequirement(name = "jwt")
-    fun changePendingStatus(promiseId: Long): ApiResponseDto<Unit>
+    fun changePendingStatus(
+        @PathVariable promiseId: Long,
+        @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<Unit>
 
     @Operation(summary = "약속 참가", description = "약속에 참가합니다.")
     @ApiResponse(

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -86,7 +86,10 @@ interface PromiseApi {
 
     @Operation(summary = "Pending Promise Role 상태 변경", description = "약속 참가 - 결제 이후 모임원의 상태를 Ready 상태로 변경합니다.")
     @SecurityRequirement(name = "jwt")
-    fun changeParticipantPendingStatus(promiseId: Long): ApiResponseDto<Unit>
+    fun changeParticipantPendingStatus(
+        @PathVariable promiseId: Long,
+        @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<Unit>
 
     @Operation(summary = "약속 취소", description = "모임원이 약속을 취소합니다.")
     @ApiResponse(

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -68,6 +68,26 @@ interface PromiseApi {
     @SecurityRequirement(name = "jwt")
     fun changePendingStatus(promiseId: Long): ApiResponseDto<Unit>
 
+    @Operation(summary = "약속 참가", description = "약속에 참가합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "약속 참가 성공",
+        content = [
+            Content(
+                schema = Schema(implementation = ApiResponseDto::class),
+            ),
+        ],
+    )
+    @SecurityRequirement(name = "jwt")
+    fun joinPromise(
+        @PathVariable promiseId: Long,
+        @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<PromiseResponseDto>
+
+    @Operation(summary = "Pending Promise Role 상태 변경", description = "약속 참가 - 결제 이후 모임원의 상태를 Ready 상태로 변경합니다.")
+    @SecurityRequirement(name = "jwt")
+    fun changeParticipantPendingStatus(promiseId: Long): ApiResponseDto<Unit>
+
     @Operation(summary = "약속 취소", description = "모임원이 약속을 취소합니다.")
     @ApiResponse(
         responseCode = "204",

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -87,7 +87,7 @@ interface PromiseApi {
     @Operation(summary = "Pending Promise Role 상태 변경", description = "약속 참가 - 결제 이후 모임원의 상태를 Ready 상태로 변경합니다.")
     @SecurityRequirement(name = "jwt")
     fun changeParticipantPendingStatus(promiseId: Long): ApiResponseDto<Unit>
-  
+
     @Operation(summary = "약속 취소", description = "모임원이 약속을 취소합니다.")
     @ApiResponse(
         responseCode = "204",

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -77,5 +77,9 @@ class PromiseController(
     @PostMapping("/{promiseId}/participant/change")
     override fun changeParticipantPendingStatus(
         @PathVariable promiseId: Long,
-    ): ApiResponseDto<Unit> = ApiResponseDto.success(promiseRoleService.changePendingStatus(promiseId))
+        @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<Unit> =
+        ApiResponseDto.success(
+            promiseRoleService.changePendingStatus(authenticatedUser.memberId, promiseId),
+        )
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.controller
 import com.pravo.pravo.domain.promise.dto.request.PromiseSearchDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseDetailResponseDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.service.PromiseFacade
 import com.pravo.pravo.domain.promise.service.PromiseRoleService
 import com.pravo.pravo.domain.promise.service.PromiseService
 import com.pravo.pravo.global.auth.annotation.AuthUser
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 class PromiseController(
     private val promiseService: PromiseService,
     private val promiseRoleService: PromiseRoleService,
+    private val promiseFacade: PromiseFacade,
 ) : PromiseApi {
     @GetMapping
     override fun getPromisesByMember(
@@ -57,4 +59,20 @@ class PromiseController(
         ApiResponseDto.success(
             promiseService.changePendingStatus(promiseId),
         )
+
+    @PostMapping("/{promiseId}/join")
+    override fun joinPromise(
+        @PathVariable promiseId: Long,
+        @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<PromiseResponseDto> =
+        ApiResponseDto.success(
+            promiseFacade.joinPromise(authenticatedUser.memberId, promiseId),
+        )
+
+    @PostMapping("/{promiseId}/participant/change")
+    override fun changeParticipantPendingStatus(
+        @PathVariable promiseId: Long,
+    ): ApiResponseDto<Unit> {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -54,7 +54,11 @@ class PromiseController(
     @PostMapping("/{promiseId}/change")
     override fun changePendingStatus(
         @PathVariable promiseId: Long,
-    ): ApiResponseDto<Unit> = ApiResponseDto.success(promiseService.changePendingStatus(promiseId))
+        @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<Unit> =
+        ApiResponseDto.success(
+            promiseFacade.changePendingStatus(authenticatedUser.memberId, promiseId),
+        )
 
     @DeleteMapping("/{promiseId}/cancel")
     override fun cancelPromise(

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -77,7 +77,5 @@ class PromiseController(
     @PostMapping("/{promiseId}/participant/change")
     override fun changeParticipantPendingStatus(
         @PathVariable promiseId: Long,
-    ): ApiResponseDto<Unit> {
-        TODO("Not yet implemented")
-    }
+    ): ApiResponseDto<Unit> = ApiResponseDto.success(promiseRoleService.changePendingStatus(promiseId))
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.controller
 import com.pravo.pravo.domain.promise.dto.request.PromiseSearchDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseDetailResponseDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.service.PromiseFacade
 import com.pravo.pravo.domain.promise.service.PromiseRoleService
 import com.pravo.pravo.domain.promise.service.PromiseService
 import com.pravo.pravo.global.auth.annotation.AuthUser
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 class PromiseController(
     private val promiseService: PromiseService,
     private val promiseRoleService: PromiseRoleService,
+    private val promiseFacade: PromiseFacade,
 ) : PromiseApi {
     @GetMapping
     override fun getPromisesByMember(
@@ -62,4 +64,20 @@ class PromiseController(
         ApiResponseDto.success(
             promiseRoleService.cancelPromise(authenticatedUser.memberId, promiseId),
         )
+
+    @PostMapping("/{promiseId}/join")
+    override fun joinPromise(
+        @PathVariable promiseId: Long,
+        @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<PromiseResponseDto> =
+        ApiResponseDto.success(
+            promiseFacade.joinPromise(authenticatedUser.memberId, promiseId),
+        )
+
+    @PostMapping("/{promiseId}/participant/change")
+    override fun changeParticipantPendingStatus(
+        @PathVariable promiseId: Long,
+    ): ApiResponseDto<Unit> {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/dto/response/PromiseResponseDto.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/dto/response/PromiseResponseDto.kt
@@ -1,5 +1,6 @@
 package com.pravo.pravo.domain.promise.dto.response
 
+import com.pravo.pravo.domain.promise.model.Promise
 import com.pravo.pravo.domain.promise.model.enums.PromiseStatus
 import com.querydsl.core.annotations.QueryProjection
 import io.swagger.v3.oas.annotations.media.Schema
@@ -19,7 +20,21 @@ class PromiseResponseDto
         @Schema(description = "약속 상태", example = "READY")
         val status: PromiseStatus,
         @Schema(description = "모임장 이름", example = "모임장 이름")
-        val organizerName: String,
+        val organizerName: String?,
         @Schema(description = "모임장 프로필 이미지", example = "모임장 프로필 이미지")
         val organizerProfileImageUrl: String?,
-    )
+    ) {
+        companion object {
+            fun of(promise: Promise): PromiseResponseDto {
+                return PromiseResponseDto(
+                    id = promise.id,
+                    name = promise.name,
+                    promiseDate = promise.promiseDate,
+                    location = promise.location,
+                    status = promise.status,
+                    organizerName = null,
+                    organizerProfileImageUrl = null,
+                )
+            }
+        }
+    }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.model;
 import com.pravo.pravo.domain.promise.dto.request.PromiseCreateDto;
 import com.pravo.pravo.domain.promise.model.enums.PromiseStatus;
 import com.pravo.pravo.global.common.model.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -44,7 +45,7 @@ public class Promise extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
-    @OneToMany(mappedBy = "promise")
+    @OneToMany(mappedBy = "promise", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PromiseRole> promiseRoles = new ArrayList<>();
 
     public Long getId() {
@@ -71,6 +72,7 @@ public class Promise extends BaseTimeEntity {
 
     public void delete() {
         this.deleted = true;
+        promiseRoles.forEach(PromiseRole::delete);
     }
 
     public List<PromiseRole> getPromiseRoles() {

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.model;
 import com.pravo.pravo.domain.promise.dto.request.PromiseCreateDto;
 import com.pravo.pravo.domain.promise.model.enums.PromiseStatus;
 import com.pravo.pravo.global.common.model.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,12 +15,10 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @SQLRestriction("deleted = false")
-@SQLDelete(sql = "UPDATE promise SET deleted = true WHERE promise_id = ?")
 public class Promise extends BaseTimeEntity {
 
     @Id
@@ -46,7 +45,7 @@ public class Promise extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
-    @OneToMany
+    @OneToMany(mappedBy = "promise", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PromiseRole> promiseRoles = new ArrayList<>();
 
     public Long getId() {
@@ -72,7 +71,9 @@ public class Promise extends BaseTimeEntity {
     public Integer getDeposit() { return this.deposit; }
 
     public void delete() {
+
         this.deleted = true;
+        promiseRoles.forEach(PromiseRole::delete);
     }
 
     public List<PromiseRole> getPromiseRoles() {

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -89,4 +89,6 @@ public class PromiseRole extends BaseTimeEntity {
     public static PromiseRole pendingOf(Promise promise, Member member) {
         return new PromiseRole(member, promise, ParticipantStatus.PENDING, RoleStatus.PARTICIPANT);
     }
+
+    public void changePendingStatus() { this.status = ParticipantStatus.READY; }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -14,12 +14,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @SQLRestriction("deleted = false")
-@SQLDelete(sql = "UPDATE promise_role SET deleted = true WHERE promise_role_id = ?")
 public class PromiseRole extends BaseTimeEntity {
 
     @Id
@@ -46,7 +44,15 @@ public class PromiseRole extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
+    public PromiseRole(Member member, Promise promise, ParticipantStatus status, RoleStatus role) {
+        this.member = member;
+        this.promise = promise;
+        this.status = status;
+        this.role = role;
+    }
+
     public PromiseRole() {
+
     }
 
     public Long getId() {
@@ -78,5 +84,9 @@ public class PromiseRole extends BaseTimeEntity {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public static PromiseRole pendingOf(Promise promise, Member member) {
+        return new PromiseRole(member, promise, ParticipantStatus.PENDING, RoleStatus.PARTICIPANT);
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -44,7 +44,15 @@ public class PromiseRole extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
+    public PromiseRole(Member member, Promise promise, ParticipantStatus status, RoleStatus role) {
+        this.member = member;
+        this.promise = promise;
+        this.status = status;
+        this.role = role;
+    }
+
     public PromiseRole() {
+
     }
 
     public Long getId() {
@@ -76,5 +84,9 @@ public class PromiseRole extends BaseTimeEntity {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public static PromiseRole pendingOf(Promise promise, Member member) {
+        return new PromiseRole(member, promise, ParticipantStatus.PENDING, RoleStatus.PARTICIPANT);
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -86,8 +86,8 @@ public class PromiseRole extends BaseTimeEntity {
         this.deleted = true;
     }
 
-    public static PromiseRole pendingOf(Promise promise, Member member) {
-        return new PromiseRole(member, promise, ParticipantStatus.PENDING, RoleStatus.PARTICIPANT);
+    public static PromiseRole pendingOf(Promise promise, Member member, RoleStatus role) {
+        return new PromiseRole(member, promise, ParticipantStatus.PENDING, role);
     }
 
     public void changePendingStatus() { this.status = ParticipantStatus.READY; }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/enums/ParticipantStatus.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/enums/ParticipantStatus.java
@@ -1,6 +1,7 @@
 package com.pravo.pravo.domain.promise.model.enums;
 
 public enum ParticipantStatus {
+    PENDING,
     READY,
     ATTENDED,
     NOT_ATTENDED,

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRepository.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRepository.java
@@ -1,6 +1,7 @@
 package com.pravo.pravo.domain.promise.repository;
 
 import com.pravo.pravo.domain.promise.model.Promise;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,5 +13,5 @@ public interface PromiseRepository extends JpaRepository<Promise, Long>, Promise
         WHERE p.id = :promiseId
         AND p.deleted = false
     """)
-    public Promise getPromiseById(Long promiseId);
+    Optional<Promise> getPromiseById(Long promiseId);
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRoleRepository.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRoleRepository.java
@@ -1,7 +1,7 @@
 package com.pravo.pravo.domain.promise.repository;
 
 import com.pravo.pravo.domain.promise.model.PromiseRole;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,7 +14,7 @@ public interface PromiseRoleRepository extends JpaRepository<PromiseRole, Long> 
     WHERE pr.promise.id = :promiseId
     AND pr.member.id = :memberId
     """)
-    public PromiseRole findByPromiseIdAndMemberId(Long promiseId, Long memberId);
+    PromiseRole findDetailByPromiseIdAndMemberId(Long promiseId, Long memberId);
 
-    public List<PromiseRole> findAllByPromiseId(Long promiseId);
+     Optional<PromiseRole> findByPromiseIdAndMemberId(Long promiseId, Long memberId);
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -1,0 +1,26 @@
+package com.pravo.pravo.domain.promise.service
+
+import com.pravo.pravo.domain.member.service.MemberService
+import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import org.springframework.stereotype.Service
+
+@Service
+class PromiseFacade(
+    private val promiseService: PromiseService,
+    private val promiseRoleService: PromiseRoleService,
+    private val memberService: MemberService,
+) {
+    fun joinPromise(
+        memberId: Long,
+        promiseId: Long,
+    ): PromiseResponseDto {
+        val promiseRole = promiseRoleService.checkPromiseRole(memberId, promiseId)
+        if (promiseRole) {
+            return PromiseResponseDto.of(promiseService.getPromise(promiseId))
+        }
+        val promise = promiseService.getPromise(promiseId)
+        val member = memberService.getMemberById(memberId)
+        promiseRoleService.createPromiseRole(member, promise)
+        return PromiseResponseDto.of(promise)
+    }
+}

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -15,8 +15,7 @@ class PromiseFacade(
         memberId: Long,
         promiseId: Long,
     ): PromiseResponseDto {
-        val promiseRole = promiseRoleService.checkPromiseRole(memberId, promiseId)
-        if (promiseRole) {
+        if (promiseRoleService.checkPromiseRole(memberId, promiseId)) {
             return PromiseResponseDto.of(promiseService.getPromise(promiseId))
         }
         val promise = promiseService.getPromise(promiseId)

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -24,4 +24,15 @@ class PromiseFacade(
         promiseRoleService.createPendingPromiseRole(member, promise, RoleStatus.PARTICIPANT)
         return PromiseResponseDto.of(promise)
     }
+
+    fun changePendingStatus(
+        memberId: Long,
+        promiseId: Long,
+    ) {
+        val promise = promiseService.getPromise(promiseId)
+        promise.changePendingStatus()
+
+        val promiseRole = promiseRoleService.getPromiseRole(memberId, promiseId)
+        promiseRole.changePendingStatus()
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -2,6 +2,7 @@ package com.pravo.pravo.domain.promise.service
 
 import com.pravo.pravo.domain.member.service.MemberService
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import org.springframework.stereotype.Service
 
 @Service
@@ -20,7 +21,7 @@ class PromiseFacade(
         }
         val promise = promiseService.getPromise(promiseId)
         val member = memberService.getMemberById(memberId)
-        promiseRoleService.createPromiseRole(member, promise)
+        promiseRoleService.createPendingPromiseRole(member, promise, RoleStatus.PARTICIPANT)
         return PromiseResponseDto.of(promise)
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -69,4 +69,13 @@ class PromiseRoleService(
             }
         promiseRole.changePendingStatus()
     }
+
+    fun getPromiseRole(
+        memberId: Long,
+        promiseId: Long,
+    ): PromiseRole {
+        return promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId).orElseThrow {
+            NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
+        }
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -1,5 +1,8 @@
 package com.pravo.pravo.domain.promise.service
 
+import com.pravo.pravo.domain.member.model.Member
+import com.pravo.pravo.domain.promise.model.Promise
+import com.pravo.pravo.domain.promise.model.PromiseRole
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
 import com.pravo.pravo.global.error.exception.UnauthorizedException
@@ -20,11 +23,21 @@ class PromiseRoleService(
                 ?.takeIf { it.isOrganizer }
                 ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 삭제할 권한이 없습니다")
 
-        // 모든 PromiseRole 조회 후 개별 delete
-        val roles = promiseRoleRepository.findAllByPromiseId(promiseId)
-        roles.forEach { it.delete() }
-
-        // Promise 삭제
         promiseRole.promise.delete()
+    }
+
+    fun createPromiseRole(
+        member: Member,
+        promise: Promise,
+    ) {
+        val promiseRole = PromiseRole.pendingOf(promise, member)
+        promiseRoleRepository.save(promiseRole)
+    }
+
+    fun checkPromiseRole(
+        memberId: Long,
+        promiseId: Long,
+    ): Boolean {
+        return promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId) != null
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.service
 import com.pravo.pravo.domain.member.model.Member
 import com.pravo.pravo.domain.promise.model.Promise
 import com.pravo.pravo.domain.promise.model.PromiseRole
+import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
 import com.pravo.pravo.global.error.exception.NotFoundException
@@ -20,18 +21,19 @@ class PromiseRoleService(
         promiseId: Long,
     ) {
         val promiseRole =
-            promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId)
+            promiseRoleRepository.findDetailByPromiseIdAndMemberId(promiseId, memberId)
                 ?.takeIf { it.isOrganizer }
                 ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 삭제할 권한이 없습니다")
 
         promiseRole.promise.delete()
     }
 
-    fun createPromiseRole(
+    fun createPendingPromiseRole(
         member: Member,
         promise: Promise,
+        role: RoleStatus,
     ) {
-        val promiseRole = PromiseRole.pendingOf(promise, member)
+        val promiseRole = PromiseRole.pendingOf(promise, member, role)
         promiseRoleRepository.save(promiseRole)
     }
 
@@ -48,7 +50,7 @@ class PromiseRoleService(
         promiseId: Long,
     ) {
         val promiseRole =
-            promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId)
+            promiseRoleRepository.findDetailByPromiseIdAndMemberId(promiseId, memberId)
                 ?.takeIf { !it.isOrganizer }
                 ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 취소할 권한이 없습니다")
 
@@ -57,9 +59,12 @@ class PromiseRoleService(
     }
 
     @Transactional
-    fun changePendingStatus(promiseId: Long) {
+    fun changePendingStatus(
+        memberId: Long,
+        promiseId: Long,
+    ) {
         val promiseRole =
-            promiseRoleRepository.findById(promiseId).orElseThrow {
+            promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId).orElseThrow {
                 NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
             }
         promiseRole.changePendingStatus()

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -1,5 +1,8 @@
 package com.pravo.pravo.domain.promise.service
 
+import com.pravo.pravo.domain.member.model.Member
+import com.pravo.pravo.domain.promise.model.Promise
+import com.pravo.pravo.domain.promise.model.PromiseRole
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
 import com.pravo.pravo.global.error.exception.UnauthorizedException
@@ -19,11 +22,23 @@ class PromiseRoleService(
             promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId)
                 ?.takeIf { it.isOrganizer }
                 ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 삭제할 권한이 없습니다")
-
-        val roles = promiseRoleRepository.findAllByPromiseId(promiseId)
-        roles.forEach { it.delete() }
         // TODO: 환불 로직 추가
         promiseRole.promise.delete()
+    }
+
+    fun createPromiseRole(
+        member: Member,
+        promise: Promise,
+    ) {
+        val promiseRole = PromiseRole.pendingOf(promise, member)
+        promiseRoleRepository.save(promiseRole)
+    }
+
+    fun checkPromiseRole(
+        memberId: Long,
+        promiseId: Long,
+    ): Boolean {
+        return promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId) != null
     }
 
     @Transactional

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -5,6 +5,7 @@ import com.pravo.pravo.domain.promise.model.Promise
 import com.pravo.pravo.domain.promise.model.PromiseRole
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
+import com.pravo.pravo.global.error.exception.NotFoundException
 import com.pravo.pravo.global.error.exception.UnauthorizedException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -53,5 +54,14 @@ class PromiseRoleService(
 
         // TODO: 수수료 부과 로직 추가
         promiseRole.delete()
+    }
+
+    @Transactional
+    fun changePendingStatus(promiseId: Long) {
+        val promiseRole =
+            promiseRoleRepository.findById(promiseId).orElseThrow {
+                NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
+            }
+        promiseRole.changePendingStatus()
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
@@ -27,7 +27,7 @@ class PromiseService(
     ): PromiseDetailResponseDto {
         val promise =
             promiseRepository.getPromiseById(promiseId).orElseThrow {
-                NotFoundException(ErrorCode.NOT_FOUND, "약속을 찾을 수 없습니다")
+                NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
             }
         val participants =
             promise.promiseRoles.map {
@@ -44,13 +44,13 @@ class PromiseService(
     fun changePendingStatus(promiseId: Long) {
         val promise =
             promiseRepository.findById(promiseId).orElseThrow {
-                NotFoundException(ErrorCode.NOT_FOUND)
+                NotFoundException(ErrorCode.BAD_REQUEST)
             }
         promise.changePendingStatus()
     }
 
     fun getPromise(promiseId: Long): Promise {
         return promiseRepository.findById(promiseId)
-            .orElseThrow { NotFoundException(ErrorCode.NOT_FOUND, "약속을 찾을 수 없습니다") }
+            .orElseThrow { NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다") }
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
@@ -26,9 +26,9 @@ class PromiseService(
         promiseId: Long,
     ): PromiseDetailResponseDto {
         val promise =
-            promiseRepository.getPromiseById(promiseId)
-                ?: throw NotFoundException(ErrorCode.NOT_FOUND, "약속을 찾을 수 없습니다")
-
+            promiseRepository.getPromiseById(promiseId).orElseThrow {
+                NotFoundException(ErrorCode.NOT_FOUND, "약속을 찾을 수 없습니다")
+            }
         val participants =
             promise.promiseRoles.map {
                 ParticipantResponseDto.of(it, it.member)
@@ -47,5 +47,10 @@ class PromiseService(
                 NotFoundException(ErrorCode.NOT_FOUND)
             }
         promise.changePendingStatus()
+    }
+
+    fun getPromise(promiseId: Long): Promise {
+        return promiseRepository.findById(promiseId)
+            .orElseThrow { NotFoundException(ErrorCode.NOT_FOUND, "약속을 찾을 수 없습니다") }
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseService.kt
@@ -41,14 +41,6 @@ class PromiseService(
         return promiseRepository.save(promise)
     }
 
-    fun changePendingStatus(promiseId: Long) {
-        val promise =
-            promiseRepository.findById(promiseId).orElseThrow {
-                NotFoundException(ErrorCode.BAD_REQUEST)
-            }
-        promise.changePendingStatus()
-    }
-
     fun getPromise(promiseId: Long): Promise {
         return promiseRepository.findById(promiseId)
             .orElseThrow { NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다") }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
#52 
## ✨ 어떤 이유로 변경된 내용인지
- 링크 기반 약속 참가를 위한 API를 개발했습니다.
- mappedBy를 추가하여 참석자들이 조회되지 않는 에러를 해결했습니다.
- member에  soft delete를 추가했습니다.
- table 변경으로 인해 잠시 ddl-auto를 create로 머지해야 할 것 같습니다.
- 사용자의 참여 상태를 변경하는 API를 개발했습니다.
- Pending 상태의 Promise 생성 시 pending 상태의 PromiseRole도 추가하도록 수정했습니다. 
- Pending 상태의 Promise 상태 변경 시 pending 상태의 PromiseRole도 함께 Ready로 변경되도록 수정했습니다. 
## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->

### 새로 만든 API 
1. /promise/{promise_id}/join
2. /{promiseId}/participant/change

### 로직을 수정한 API
1. /promise/{promiseId}/change
2. /request