### PR TITLE
[FEAT] 정산하기 API

### DIFF
--- a/src/main/kotlin/com/pravo/pravo/domain/fine/service/FineLogService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/fine/service/FineLogService.kt
@@ -2,13 +2,14 @@ package com.pravo.pravo.domain.fine.service
 
 import com.pravo.pravo.domain.fine.model.FineLog
 import com.pravo.pravo.domain.fine.repository.FineLogRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
 class FineLogService(
     private val fineLogRepository: FineLogRepository,
 ) {
-    // TODO 정산 로직에서 사용
+    @Transactional
     fun saveFineLog(
         amount: Long,
         memberId: Long,

--- a/src/main/kotlin/com/pravo/pravo/domain/member/model/Member.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/member/model/Member.java
@@ -58,4 +58,8 @@ public class Member extends BaseTimeEntity {
     public void setProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }
+
+    public void updatePoint(Long point) {
+        this.point += point;
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/payment/repository/PaymentLogRepository.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/payment/repository/PaymentLogRepository.java
@@ -3,10 +3,8 @@ package com.pravo.pravo.domain.payment.repository;
 import com.pravo.pravo.domain.payment.model.PaymentLog;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> {
 
-    @Query("SELECT pr FROM PromiseRole pr JOIN FETCH pr.member WHERE pr.promise.id = :promiseId AND pr.member.id = :memberId")
     Optional<PaymentLog> findByMemberIdAndPromiseId(Long memberId, Long promiseId);
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/payment/repository/PaymentLogRepository.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/payment/repository/PaymentLogRepository.java
@@ -3,8 +3,10 @@ package com.pravo.pravo.domain.payment.repository;
 import com.pravo.pravo.domain.payment.model.PaymentLog;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PaymentLogRepository extends JpaRepository<PaymentLog, String> {
 
+    @Query("SELECT pr FROM PromiseRole pr JOIN FETCH pr.member WHERE pr.promise.id = :promiseId AND pr.member.id = :memberId")
     Optional<PaymentLog> findByMemberIdAndPromiseId(Long memberId, Long promiseId);
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentService.kt
@@ -14,6 +14,7 @@ import com.pravo.pravo.global.error.exception.NotFoundException
 import com.pravo.pravo.global.external.toss.PaymentClient
 import com.pravo.pravo.global.external.toss.dto.request.CancelRequestDto
 import com.pravo.pravo.global.util.logger
+import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -66,7 +67,7 @@ class PaymentService(
         return newKey
     }
 
-    // TODO 약속 정산 부분에서 호출
+    @Transactional
     fun cancelPayment(
         promiseId: Long,
         memberId: Long,

--- a/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/payment/service/PaymentService.kt
@@ -74,7 +74,7 @@ class PaymentService(
     ) {
         val paymentLog =
             paymentLogRepository.findByMemberIdAndPromiseId(memberId, promiseId).orElseThrow {
-                NotFoundException(ErrorCode.NOT_FOUND)
+                NotFoundException(ErrorCode.NOT_FOUND, "결제 정보를 찾을 수 없습니다")
             }
 
         val idempotencyKey = getOrCreateIdempotencyKey(promiseId, memberId)

--- a/src/main/kotlin/com/pravo/pravo/domain/point/service/PointLogService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/point/service/PointLogService.kt
@@ -3,13 +3,14 @@ package com.pravo.pravo.domain.point.service
 import com.pravo.pravo.domain.point.model.PointLog
 import com.pravo.pravo.domain.point.model.PointLogStatus
 import com.pravo.pravo.domain.point.repository.PointLogRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
 class PointLogService(
     private val pointLogRepository: PointLogRepository,
 ) {
-    // TODO 약속 정산에서 호출
+    @Transactional
     fun savePointLog(
         pointLogStatus: PointLogStatus,
         amount: Long,

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -105,4 +105,20 @@ interface PromiseApi {
         @PathVariable promiseId: Long,
         @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
     ): ApiResponseDto<Unit>
+
+    @Operation(summary = "약속 정산 조회", description = "약속을 생성합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "약속 정산 조회 성공",
+        content = [
+            Content(
+                schema = Schema(implementation = ApiResponseDto::class),
+            ),
+        ],
+    )
+    @SecurityRequirement(name = "jwt")
+    fun getPromiseSettlement(
+        @PathVariable promiseId: Long,
+        @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<Unit>
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseApi.kt
@@ -1,8 +1,10 @@
 package com.pravo.pravo.domain.promise.controller
 
 import com.pravo.pravo.domain.promise.dto.request.PromiseSearchDto
+import com.pravo.pravo.domain.promise.dto.request.PromiseSettlementRequestDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseDetailResponseDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.dto.response.PromiseSettlementResponseDto
 import com.pravo.pravo.global.auth.annotation.AuthUser
 import com.pravo.pravo.global.common.ApiResponseDto
 import com.pravo.pravo.global.jwt.AuthenticateUser
@@ -16,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @Tag(name = "Promise", description = "약속 API")
@@ -106,10 +109,10 @@ interface PromiseApi {
         @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
     ): ApiResponseDto<Unit>
 
-    @Operation(summary = "약속 정산 조회", description = "약속을 생성합니다.")
+    @Operation(summary = "약속 정산하기", description = "약속을 정산합니다")
     @ApiResponse(
         responseCode = "200",
-        description = "약속 정산 조회 성공",
+        description = "약속 정산 성공",
         content = [
             Content(
                 schema = Schema(implementation = ApiResponseDto::class),
@@ -117,8 +120,8 @@ interface PromiseApi {
         ],
     )
     @SecurityRequirement(name = "jwt")
-    fun getPromiseSettlement(
-        @PathVariable promiseId: Long,
+    fun settlePromise(
+        @RequestBody settlementRequest: PromiseSettlementRequestDto,
         @Parameter(hidden = true) @AuthUser authenticatedUser: AuthenticateUser,
-    ): ApiResponseDto<Unit>
+    ): ApiResponseDto<PromiseSettlementResponseDto>
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -52,7 +52,7 @@ class PromiseController(
         @AuthUser authenticatedUser: AuthenticateUser,
     ): ApiResponseDto<Unit> =
         ApiResponseDto.success(
-            promiseRoleService.deletePromise(authenticatedUser.memberId, promiseId),
+            promiseSettlementFacade.deletePromise(authenticatedUser.memberId, promiseId),
         )
 
     @PostMapping("/{promiseId}/change")

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -1,11 +1,14 @@
 package com.pravo.pravo.domain.promise.controller
 
 import com.pravo.pravo.domain.promise.dto.request.PromiseSearchDto
+import com.pravo.pravo.domain.promise.dto.request.PromiseSettlementRequestDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseDetailResponseDto
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.dto.response.PromiseSettlementResponseDto
 import com.pravo.pravo.domain.promise.service.PromiseFacade
 import com.pravo.pravo.domain.promise.service.PromiseRoleService
 import com.pravo.pravo.domain.promise.service.PromiseService
+import com.pravo.pravo.domain.promise.service.PromiseSettlementFacade
 import com.pravo.pravo.global.auth.annotation.AuthUser
 import com.pravo.pravo.global.common.ApiResponseDto
 import com.pravo.pravo.global.jwt.AuthenticateUser
@@ -22,6 +25,7 @@ class PromiseController(
     private val promiseService: PromiseService,
     private val promiseRoleService: PromiseRoleService,
     private val promiseFacade: PromiseFacade,
+    private val promiseSettlementFacade: PromiseSettlementFacade,
 ) : PromiseApi {
     @GetMapping
     override fun getPromisesByMember(
@@ -60,22 +64,14 @@ class PromiseController(
             promiseFacade.changePendingStatus(authenticatedUser.memberId, promiseId),
         )
 
-    @DeleteMapping("/{promiseId}/cancel")
+    @DeleteMapping("/{promiseId}/participant")
     override fun cancelPromise(
         @PathVariable promiseId: Long,
         @AuthUser authenticatedUser: AuthenticateUser,
     ): ApiResponseDto<Unit> =
         ApiResponseDto.success(
-            promiseRoleService.cancelPromise(authenticatedUser.memberId, promiseId),
+            promiseSettlementFacade.cancelPromise(authenticatedUser.memberId, promiseId),
         )
-
-    @GetMapping("/{promiseId}/settlement")
-    override fun getPromiseSettlement(
-        @PathVariable promiseId: Long,
-        @AuthUser authenticatedUser: AuthenticateUser
-    ): ApiResponseDto<Unit> {
-        TODO("Not yet implemented")
-    }
 
     @PostMapping("/{promiseId}/join")
     override fun joinPromise(
@@ -93,5 +89,14 @@ class PromiseController(
     ): ApiResponseDto<Unit> =
         ApiResponseDto.success(
             promiseRoleService.changePendingStatus(authenticatedUser.memberId, promiseId),
+        )
+
+    @PostMapping("/{promiseId}/participants")
+    override fun settlePromise(
+        settlementRequest: PromiseSettlementRequestDto,
+        @AuthUser authenticatedUser: AuthenticateUser,
+    ): ApiResponseDto<PromiseSettlementResponseDto> =
+        ApiResponseDto.success(
+            promiseSettlementFacade.settlePromise(authenticatedUser.memberId, settlementRequest),
         )
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/controller/PromiseController.kt
@@ -69,6 +69,14 @@ class PromiseController(
             promiseRoleService.cancelPromise(authenticatedUser.memberId, promiseId),
         )
 
+    @GetMapping("/{promiseId}/settlement")
+    override fun getPromiseSettlement(
+        @PathVariable promiseId: Long,
+        @AuthUser authenticatedUser: AuthenticateUser
+    ): ApiResponseDto<Unit> {
+        TODO("Not yet implemented")
+    }
+
     @PostMapping("/{promiseId}/join")
     override fun joinPromise(
         @PathVariable promiseId: Long,

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/dto/request/PromiseSettlementRequestDto.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/dto/request/PromiseSettlementRequestDto.kt
@@ -1,0 +1,6 @@
+package com.pravo.pravo.domain.promise.dto.request
+
+data class PromiseSettlementRequestDto(
+    val memberIds: List<Long>,
+    val promiseId: Long,
+)

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/dto/response/PromiseSettlementResponseDto.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/dto/response/PromiseSettlementResponseDto.kt
@@ -1,0 +1,18 @@
+package com.pravo.pravo.domain.promise.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+class PromiseSettlementResponseDto(
+    @Schema(description = "약속 ID", example = "1")
+    val id: Long,
+    @Schema(description = "약속 이름", example = "약속 이름")
+    val name: String,
+    @Schema(description = "예약금", example = "10000")
+    val deposit: Int,
+    @Schema(description = "지급포인트", example = "100")
+    val earnedPoint: Long,
+    @Schema(description = "참석자 수", example = "3")
+    val attendanceCount: Int,
+    @Schema(description = "결시자 수", example = "1")
+    val absentCount: Int,
+)

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
@@ -104,4 +104,8 @@ public class Promise extends BaseTimeEntity {
     public void changePendingStatus() {
         this.status = PromiseStatus.READY;
     }
+
+    public void changeCompletedStatus() {
+        this.status = PromiseStatus.COMPLETED;
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/Promise.java
@@ -101,11 +101,7 @@ public class Promise extends BaseTimeEntity {
         );
     }
 
-    public void changePendingStatus() {
-        this.status = PromiseStatus.READY;
-    }
-
-    public void changeCompletedStatus() {
-        this.status = PromiseStatus.COMPLETED;
+    public void updateStatus(PromiseStatus newStatus) {
+        this.status = newStatus;
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -90,8 +90,6 @@ public class PromiseRole extends BaseTimeEntity {
         return new PromiseRole(member, promise, ParticipantStatus.PENDING, role);
     }
 
-    public void changePendingStatus() { this.status = ParticipantStatus.READY; }
-
     public void updateStatus(ParticipantStatus newStatus) {
         this.status = newStatus;
     }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/model/PromiseRole.java
@@ -91,4 +91,8 @@ public class PromiseRole extends BaseTimeEntity {
     }
 
     public void changePendingStatus() { this.status = ParticipantStatus.READY; }
+
+    public void updateStatus(ParticipantStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRoleRepository.java
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/repository/PromiseRoleRepository.java
@@ -1,6 +1,8 @@
 package com.pravo.pravo.domain.promise.repository;
 
 import com.pravo.pravo.domain.promise.model.PromiseRole;
+import com.pravo.pravo.domain.promise.model.enums.ParticipantStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +19,8 @@ public interface PromiseRoleRepository extends JpaRepository<PromiseRole, Long> 
     PromiseRole findDetailByPromiseIdAndMemberId(Long promiseId, Long memberId);
 
      Optional<PromiseRole> findByPromiseIdAndMemberId(Long promiseId, Long memberId);
+
+     List<PromiseRole> findByPromiseIdAndStatus(Long promiseId, ParticipantStatus participantStatus);
+
+     Boolean existsByPromiseIdAndMemberId(Long promiseId, Long memberId);
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -12,6 +12,7 @@ class PromiseFacade(
     private val promiseRoleService: PromiseRoleService,
     private val memberService: MemberService,
 ) {
+    @Transactional
     fun joinPromise(
         memberId: Long,
         promiseId: Long,

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseFacade.kt
@@ -2,6 +2,8 @@ package com.pravo.pravo.domain.promise.service
 
 import com.pravo.pravo.domain.member.service.MemberService
 import com.pravo.pravo.domain.promise.dto.response.PromiseResponseDto
+import com.pravo.pravo.domain.promise.model.enums.ParticipantStatus
+import com.pravo.pravo.domain.promise.model.enums.PromiseStatus
 import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -32,9 +34,9 @@ class PromiseFacade(
         promiseId: Long,
     ) {
         val promise = promiseService.getPromise(promiseId)
-        promise.changePendingStatus()
+        promise.updateStatus(PromiseStatus.READY)
 
         val promiseRole = promiseRoleService.getPromiseRole(memberId, promiseId)
-        promiseRole.changePendingStatus()
+        promiseRole.updateStatus(ParticipantStatus.READY)
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -8,7 +8,6 @@ import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
 import com.pravo.pravo.global.error.exception.NotFoundException
-import com.pravo.pravo.global.error.exception.UnauthorizedException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
@@ -16,19 +15,6 @@ import org.springframework.stereotype.Service
 class PromiseRoleService(
     private val promiseRoleRepository: PromiseRoleRepository,
 ) {
-    @Transactional
-    fun deletePromise(
-        memberId: Long,
-        promiseId: Long,
-    ) {
-        val promiseRole =
-            promiseRoleRepository.findDetailByPromiseIdAndMemberId(promiseId, memberId)
-                ?.takeIf { it.isOrganizer }
-                ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 삭제할 권한이 없습니다")
-        // TODO: 환불 로직 추가
-        promiseRole.promise.delete()
-    }
-
     fun createPendingPromiseRole(
         member: Member,
         promise: Promise,
@@ -54,7 +40,7 @@ class PromiseRoleService(
             promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId).orElseThrow {
                 NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
             }
-        promiseRole.changePendingStatus()
+        promiseRole.updateStatus(ParticipantStatus.READY)
     }
 
     fun getPromiseRole(

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseRoleService.kt
@@ -3,6 +3,7 @@ package com.pravo.pravo.domain.promise.service
 import com.pravo.pravo.domain.member.model.Member
 import com.pravo.pravo.domain.promise.model.Promise
 import com.pravo.pravo.domain.promise.model.PromiseRole
+import com.pravo.pravo.domain.promise.model.enums.ParticipantStatus
 import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import com.pravo.pravo.domain.promise.repository.PromiseRoleRepository
 import com.pravo.pravo.global.error.ErrorCode
@@ -41,21 +42,7 @@ class PromiseRoleService(
         memberId: Long,
         promiseId: Long,
     ): Boolean {
-        return promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId) != null
-    }
-
-    @Transactional
-    fun cancelPromise(
-        memberId: Long,
-        promiseId: Long,
-    ) {
-        val promiseRole =
-            promiseRoleRepository.findDetailByPromiseIdAndMemberId(promiseId, memberId)
-                ?.takeIf { !it.isOrganizer }
-                ?: throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "약속을 취소할 권한이 없습니다")
-
-        // TODO: 수수료 부과 로직 추가
-        promiseRole.delete()
+        return promiseRoleRepository.existsByPromiseIdAndMemberId(promiseId, memberId)
     }
 
     @Transactional
@@ -77,5 +64,12 @@ class PromiseRoleService(
         return promiseRoleRepository.findByPromiseIdAndMemberId(promiseId, memberId).orElseThrow {
             NotFoundException(ErrorCode.BAD_REQUEST, "약속을 찾을 수 없습니다")
         }
+    }
+
+    fun getParticipantsByStatus(
+        promiseId: Long,
+        status: ParticipantStatus,
+    ): List<PromiseRole> {
+        return promiseRoleRepository.findByPromiseIdAndStatus(promiseId, status)
     }
 }

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
@@ -15,8 +15,8 @@ import com.pravo.pravo.domain.promise.model.enums.RoleStatus
 import com.pravo.pravo.global.error.ErrorCode
 import com.pravo.pravo.global.error.exception.BadRequestException
 import com.pravo.pravo.global.error.exception.UnauthorizedException
+import com.pravo.pravo.global.util.logger
 import jakarta.transaction.Transactional
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
@@ -1,0 +1,201 @@
+package com.pravo.pravo.domain.promise.service
+
+import com.pravo.pravo.domain.fine.service.FineLogService
+import com.pravo.pravo.domain.member.model.Member
+import com.pravo.pravo.domain.payment.service.PaymentService
+import com.pravo.pravo.domain.point.model.PointLogStatus
+import com.pravo.pravo.domain.point.service.PointLogService
+import com.pravo.pravo.domain.promise.dto.request.PromiseSettlementRequestDto
+import com.pravo.pravo.domain.promise.dto.response.PromiseSettlementResponseDto
+import com.pravo.pravo.domain.promise.model.Promise
+import com.pravo.pravo.domain.promise.model.PromiseRole
+import com.pravo.pravo.domain.promise.model.enums.ParticipantStatus
+import com.pravo.pravo.domain.promise.model.enums.PromiseStatus
+import com.pravo.pravo.domain.promise.model.enums.RoleStatus
+import com.pravo.pravo.global.error.ErrorCode
+import com.pravo.pravo.global.error.exception.BadRequestException
+import com.pravo.pravo.global.error.exception.UnauthorizedException
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class PromiseSettlementFacade(
+    private val promiseService: PromiseService,
+    private val promiseRoleService: PromiseRoleService,
+    private val pointLogService: PointLogService,
+    private val paymentService: PaymentService,
+    private val fineLogService: FineLogService,
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(PromiseSettlementFacade::class.java)
+    }
+
+    @Transactional
+    fun settlePromise(
+        memberId: Long,
+        settlementRequest: PromiseSettlementRequestDto,
+    ): PromiseSettlementResponseDto {
+        val promise = promiseService.getPromise(settlementRequest.promiseId)
+        val participants = validateAndGetParticipants(promise, memberId)
+
+        val (attendees, absentees) =
+            updateAndSplitParticipants(
+                participants = participants,
+                attendedMemberIds = settlementRequest.memberIds,
+            )
+        promise.changeCompletedStatus()
+        return if (attendees.isEmpty()) {
+            processEmptyAttendees(absentees, promise)
+        } else {
+            processSettlement(attendees, absentees, promise)
+        }
+    }
+
+    private fun processEmptyAttendees(
+        absentees: List<PromiseRole>,
+        promise: Promise,
+    ): PromiseSettlementResponseDto {
+        absentees.forEach {
+            it.updateStatus(ParticipantStatus.NOT_ATTENDED)
+            fineLogService.saveFineLog(promise.deposit.toLong(), it.member.id, promise.id)
+        }
+
+        return PromiseSettlementResponseDto(
+            promise.id,
+            promise.name,
+            promise.deposit,
+            0L,
+            0,
+            absentees.size,
+        )
+    }
+
+    private fun processSettlement(
+        attendees: List<PromiseRole>,
+        absentees: List<PromiseRole>,
+        promise: Promise,
+    ): PromiseSettlementResponseDto {
+        val earnedPoint = calculateEarnedPoint(attendees, absentees, promise.deposit)
+
+        processSettlementWithValidation(
+            attendees = attendees,
+            absentees = absentees,
+            earnedPoint = earnedPoint,
+            promiseId = promise.id,
+            deposit = promise.deposit,
+        )
+
+        return PromiseSettlementResponseDto(
+            promise.id,
+            promise.name,
+            promise.deposit,
+            earnedPoint,
+            attendees.size,
+            absentees.size,
+        )
+    }
+
+    private fun validateAndGetParticipants(
+        promise: Promise,
+        memberId: Long,
+    ): List<PromiseRole> {
+        if (promise.status != PromiseStatus.READY) {
+            throw BadRequestException("이미 정산된 약속이거나 아직 진행 중인 약속입니다.")
+        }
+
+        val participants = promiseRoleService.getParticipantsByStatus(promise.id, ParticipantStatus.READY)
+        val organizer =
+            participants.find { it.role == RoleStatus.ORGANIZER }
+                ?: throw IllegalStateException("모임장이 존재하지 않습니다.")
+
+        if (organizer.member.id != memberId) {
+            throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "모임장만 정산을 진행할 수 있습니다.")
+        }
+
+        return participants
+    }
+
+    private fun processSettlementWithValidation(
+        attendees: List<PromiseRole>,
+        absentees: List<PromiseRole>,
+        earnedPoint: Long,
+        promiseId: Long,
+        deposit: Int,
+    ) {
+        val cancelResults =
+            attendees.map { attendee ->
+                try {
+//                paymentService.cancelPayment(attendee.member.id, promiseId)
+                    true
+                } catch (e: Exception) {
+                    log.error("Failed to cancel payment for member ${attendee.member.id}: ${e.message}")
+                    throw IllegalStateException("결제 취소 실패로 인해 정산을 진행할 수 없습니다: ${e.message}")
+                }
+            }
+
+        if (cancelResults.all { it }) {
+            attendees.forEach { attendee ->
+                try {
+                    settlePoint(earnedPoint, attendee.member, promiseId)
+                } catch (e: Exception) {
+                    log.error("Failed to settle points for member ${attendee.member.id}: ${e.message}")
+                    throw IllegalStateException("포인트 정산 실패: ${e.message}")
+                }
+            }
+            absentees.forEach { fineLogService.saveFineLog(deposit.toLong(), it.member.id, promiseId) }
+        }
+    }
+
+    fun calculateEarnedPoint(
+        attendees: List<PromiseRole>,
+        absentees: List<PromiseRole>,
+        deposit: Int,
+    ): Long {
+        val totalPoint = absentees.size * deposit.toLong()
+        return totalPoint / attendees.size
+    }
+
+    fun settlePoint(
+        earnedPoint: Long,
+        member: Member,
+        promiseId: Long,
+    ) {
+        pointLogService.savePointLog(PointLogStatus.PLUS, earnedPoint, member.id, promiseId)
+        member.updatePoint(earnedPoint)
+    }
+
+    @Transactional
+    fun cancelPromise(
+        memberId: Long,
+        promiseId: Long,
+    ) {
+        val promiseRole = promiseRoleService.getPromiseRole(memberId, promiseId)
+        if (promiseRole.role == RoleStatus.ORGANIZER) {
+            throw UnauthorizedException(ErrorCode.UNAUTHORIZED, "모임장은 약속을 취소할 수 없습니다.")
+        }
+
+        paymentService.cancelPayment(memberId, promiseId)
+        promiseRole.updateStatus(ParticipantStatus.CANCELED)
+    }
+
+    private fun updateAndSplitParticipants(
+        participants: List<PromiseRole>,
+        attendedMemberIds: List<Long>,
+    ): Pair<List<PromiseRole>, List<PromiseRole>> {
+        return participants
+            .map { participant ->
+                val newStatus =
+                    if (attendedMemberIds.contains(participant.member.id)) {
+                        ParticipantStatus.ATTENDED
+                    } else {
+                        ParticipantStatus.NOT_ATTENDED
+                    }
+                participant.updateStatus(newStatus)
+                participant
+            }
+            .partition { participant ->
+                participant.status == ParticipantStatus.ATTENDED
+            }
+    }
+}

--- a/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
+++ b/src/main/kotlin/com/pravo/pravo/domain/promise/service/PromiseSettlementFacade.kt
@@ -27,9 +27,7 @@ class PromiseSettlementFacade(
     private val paymentService: PaymentService,
     private val fineLogService: FineLogService,
 ) {
-    companion object {
-        private val log = LoggerFactory.getLogger(PromiseSettlementFacade::class.java)
-    }
+    val log = logger()
 
     @Transactional
     fun settlePromise(

--- a/src/main/kotlin/com/pravo/pravo/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/pravo/pravo/global/error/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.pravo.pravo.global.error
 
 import com.pravo.pravo.global.common.ApiResponseDto
+import com.pravo.pravo.global.error.exception.BadRequestException
 import com.pravo.pravo.global.error.exception.BaseException
 import com.pravo.pravo.global.error.exception.NotFoundException
 import com.pravo.pravo.global.error.exception.UnauthorizedException
@@ -78,6 +79,20 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException::class)
     fun handleUnauthorizedException(e: UnauthorizedException): ResponseEntity<ApiResponseDto<Nothing>> {
+        val errorCode = e.errorCode
+        val response =
+            ApiResponseDto.error(
+                e.message ?: errorCode.message,
+                errorCode.status,
+                errorCode.code,
+            )
+
+        logger.error(e.message, e)
+        return ResponseEntity.status(errorCode.status).body(response)
+    }
+
+    @ExceptionHandler(BadRequestException::class)
+    fun handleBadRequestException(e: BadRequestException): ResponseEntity<ApiResponseDto<Nothing>> {
         val errorCode = e.errorCode
         val response =
             ApiResponseDto.error(

--- a/src/main/kotlin/com/pravo/pravo/global/error/exception/BadRequestException.java
+++ b/src/main/kotlin/com/pravo/pravo/global/error/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.pravo.pravo.global.error.exception;
+
+import com.pravo.pravo.global.error.ErrorCode;
+
+public class BadRequestException extends BaseException {
+    public BadRequestException() {
+        super(ErrorCode.BAD_REQUEST);
+    }
+
+    public BadRequestException(String message) {
+        super(ErrorCode.BAD_REQUEST, message);
+    }
+
+}

--- a/src/main/kotlin/com/pravo/pravo/global/error/exception/BaseException.java
+++ b/src/main/kotlin/com/pravo/pravo/global/error/exception/BaseException.java
@@ -1,9 +1,6 @@
 package com.pravo.pravo.global.error.exception;
 
 import com.pravo.pravo.global.error.ErrorCode;
-import com.pravo.pravo.global.error.ErrorCode;
-import com.pravo.pravo.global.error.ErrorCode;
-import com.pravo.pravo.global.error.ErrorCode;
 
 public class BaseException extends RuntimeException {
     public final ErrorCode errorCode;


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
#68 


## ✨ 어떤 이유로 변경된 내용인지
정산기능을 만들었습니다.
1. cancel을 하면 결제 취소 + Fine Log가 남도록 했습니다. + Participant 상태 CANCELED로 업데이트
2. 정산을 하면 
 a. 참석자들은 결제 취소 + Point Log + Member테이블에 Point 업데이트 + Participant 상태 ATTENDED로 업데이트
 b. 결시자들은 Fine Log + Participant 상태 NOT_ATTENDED로 업데이트
3. 약속은 PromiseStatus가 COMPLETED로 변경

4. 참석자가 없을 경우 바로 processEmptyAttendees를 실행하도록 했습니다.
5. Payment 취소를 제대로 테스트하지 못해서 우선 주석으로 남겨두었습니다. 다음에 지함이랑 같이 만나서 해보겠습니다.
< Resolved [feign.FeignException$Unauthorized: [401 Unauthorized] during [POST] to [https://api.tosspayments.com/v1/payments/1/cancel] >
6. PromiseStatus.READY가 아닌 경우, 요청자가 RoleStatus.ORGANIZER가 아닌 경우, 정산하지 못하도록 막아두었습니다.

7. 모임장이 약속을 Delete했을 때는 Promise 상태 + 참가자들의 Partiicpant 상태를 모두 Cancle로 만들고 soft delete하도록 했습니다.
## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
